### PR TITLE
Fix generate function for publish-local

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,4 +32,3 @@ lazy val core = project
 
 addCommandAlias("make", "compile")
 
-

--- a/build.sbt
+++ b/build.sbt
@@ -32,5 +32,4 @@ lazy val core = project
 
 addCommandAlias("make", "compile")
 
-sources in (Compile,doc) := Seq.empty
-publishArtifact in (Compile, packageDoc) := false
+

--- a/build.sbt
+++ b/build.sbt
@@ -32,3 +32,5 @@ lazy val core = project
 
 addCommandAlias("make", "compile")
 
+sources in (Compile,doc) := Seq.empty
+publishArtifact in (Compile, packageDoc) := false

--- a/core/src/argon/ops/Functions.scala
+++ b/core/src/argon/ops/Functions.scala
@@ -13,8 +13,8 @@ trait FunctionApi extends FunctionExp {
 }
 
 @generate
-trait FunctionExp {
-  self: ArgonExp =>
+trait FunctionCC {
+  self: ArgonExp with FunctionExp=>
 
   case class FunApplyJJ$JJ$1to22[TII$II$1toJJ, R:Type](fun: Exp[ArgonFunctionJJ[TII$II$1toJJ, R]], argII$II$1toJJ: Exp[TII])(implicit evII$II$1toJJ: Type[TII]) extends Op[R] {
     def mirror(f: Tx): Exp[R] = {
@@ -28,8 +28,6 @@ trait FunctionExp {
     override def binds = dyns(argII$II$1toJJ) ++ super.binds
   }
 
-  def fun_applyJJ$JJ$1to22[TII$II$1toJJ, R:Type](f: Exp[ArgonFunctionJJ[TII$II$1toJJ,R]], argII$II$1toJJ: Exp[TII])(implicit evII$II$1toJJ: Type[TII], ctx: SrcCtx): Exp[R] = stage(FunApplyJJ(f, argII$II$1toJJ))(ctx)
-
   case class ArgonFunctionJJ$JJ$1to22[TII$II$1toJJ, R:Type](s: Exp[ArgonFunctionJJ[TII$II$1toJJ, R]])(implicit evII$II$1toJJ: Type[TII]) extends MetaAny[ArgonFunctionJJ[TII$II$1toJJ,R]] with FunctionJJ[TII$II$1toJJ, R] {
     @api def ===(that: ArgonFunctionJJ[TII$II$1toJJ, R]) = ???
     @api def =!=(that: ArgonFunctionJJ[TII$II$1toJJ, R]) = ???
@@ -39,6 +37,18 @@ trait FunctionExp {
     @api def applyArg(xII$II$1toJJ: TII): R = wrap(fun_applyJJ(s, xII$II$1toJJ.s))
   }
 
+  
+}
+trait FunctionExp extends FunctionCC {
+  self: ArgonExp =>
+
+
+  @generate  
+  def fun_applyJJ$JJ$1to22[TII$II$1toJJ, R:Type](f: Exp[ArgonFunctionJJ[TII$II$1toJJ,R]], argII$II$1toJJ: Exp[TII])(implicit evII$II$1toJJ: Type[TII], ctx: SrcCtx): Exp[R] = stage(FunApplyJJ(f, argII$II$1toJJ))(ctx)
+
+
+
+  @generate  
   def fun$JJ$1to22[TII$II$1toJJ, R:Type](f: FunctionJJ[TII$II$1toJJ, R])(implicit evII$II$1toJJ: Type[TII], ctx: SrcCtx): ArgonFunctionJJ[TII$II$1toJJ,R] = {
     lazy val argII$II$1toJJ = fresh[TII]
     lazy val wargII$II$1toJJ = wrap(argII)
@@ -48,6 +58,7 @@ trait FunctionExp {
   }
 
   /** Type classes **/
+  @generate  
   case class ArgonFunctionJJType$JJ$1to22[TII$II$1toJJ, R](childTII$II$1toJJ: Type[TII], childR: Type[R]) extends Meta[ArgonFunctionJJ[TII$II$1toJJ, R]] {
     override def wrapped(x: Exp[ArgonFunctionJJ[TII$II$1toJJ,R]]) = ArgonFunctionJJ(x)(childR, childTII$II$1toJJ)
     override def unwrapped(x: ArgonFunctionJJ[TII$II$1toJJ,R]) = x.s
@@ -55,7 +66,8 @@ trait FunctionExp {
     override def typeArguments = List(childTII$II$1toJJ, childR)
     override def isPrimitive: Boolean = false
   }
-
+  
+  @generate
   implicit def argonFunctionJJ$JJ$1to22[TII$II$1toJJ, R:Type](implicit evII$II$1toJJ: Type[TII]): ArgonFunctionJJType[TII$II$1toJJ,R] = {
     ArgonFunctionJJType(evII$II$1toJJ, meta[R])
   }

--- a/forge/src/forge/GenerateTransformer.scala
+++ b/forge/src/forge/GenerateTransformer.scala
@@ -6,8 +6,8 @@ import scala.reflect.macros.blackbox
 class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
   import c.universe._
 
-   val transformer = new Tx
-   val checker = new Check
+  private val transformer = new Tx
+  private val checker = new Check
   def apply[T<:Tree](x: T): List[T] = {
     var round = 0
     var level: List[T] = List(x)
@@ -24,12 +24,12 @@ class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
     level
   }
 
-   def needsUnroll(x: Tree): Boolean = checker.check(x)
+  private def needsUnroll(x: Tree): Boolean = checker.check(x)
 
   object Ranged {
-     val Numbered = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)".r
-     val Until = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)until([0-9]+)".r
-     val To = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)to([0-9]+)".r
+    private val Numbered = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)".r
+    private val Until = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)until([0-9]+)".r
+    private val To = "([a-zA-Z0-9_]+)\\$([^$]*)\\$([0-9]+)to([0-9]+)".r
 
     def unapply(x: String): Option[(String,String,Range)] = x match {
       case Numbered(name,pattern,num) => Some((name,pattern,0 until num.toInt))
@@ -51,9 +51,9 @@ class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
     }
   }
   object Repeat {
-     val Numbered = "\\$([^$]*)\\$([0-9]+)".r
-     val Until = "\\$([^$]*)\\$([0-9]+)until([0-9]+)".r
-     val To = "\\$([^$]*)\\$([0-9]+)to([0-9]+)".r
+    private val Numbered = "\\$([^$]*)\\$([0-9]+)".r
+    private val Until = "\\$([^$]*)\\$([0-9]+)until([0-9]+)".r
+    private val To = "\\$([^$]*)\\$([0-9]+)to([0-9]+)".r
 
     def unapply(x: String): Option[(String,Range)] = x match {
       case Numbered(pattern,num) => Some((pattern,0 until num.toInt))
@@ -80,7 +80,7 @@ class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
     case TypeName(name) => Ranged.unapply(name).isDefined
   }
 
-   class Check extends Traverser {
+  private class Check extends Traverser {
     var needsUnroll: Boolean = false
     override def traverse(tree: Tree): Unit = tree match {
       case x: ValDef if willUnroll(x.name)    => needsUnroll = true
@@ -106,7 +106,7 @@ class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
   }
 
 
-   class Tx extends Transformer {
+  private class Tx extends Transformer {
     var subst: Map[String,Any] = Map.empty
 
     implicit class RangeTx(x: Range) {
@@ -123,7 +123,7 @@ class GenerateTransformer[Ctx <: blackbox.Context](val c: Ctx) {
       result
     }
 
-     def checkName(orig: String, repl: String): Unit = {
+    private def checkName(orig: String, repl: String): Unit = {
       if (orig forall Character.isDigit) {
         c.error(c.enclosingPosition, s"Cannot unroll ${orig}, as this would create an illegal name $repl")
       }


### PR DESCRIPTION
This make no sense but this fix the issue of publish-local with generate and functions. If case class are inside FunctionExp, you can either never unroll or get this:

[error] /home/atoll/spatial-lang/argon/core/src/argon/ops/Functions.scala:35: private[this] not allowed for case class parameters
