### PR TITLE
Uncommented accel stream interface

### DIFF
--- a/core/src/argon/codegen/chiselgen/ChiselFileGen.scala
+++ b/core/src/argon/codegen/chiselgen/ChiselFileGen.scala
@@ -195,7 +195,7 @@ import types._
         emit("val argOuts = Vec(io_numArgOuts, Decoupled((UInt(64.W))))")
         emit("")
         emit("// Stream IO")
-        emit("// val genericStreams = new GenericStreams(io_streamInsInfo, io_streamOutsInfo)")
+        emit("val genericStreams = new GenericStreams(io_streamInsInfo, io_streamOutsInfo)")
         emit("// Video Stream Inputs ")
         emit("val stream_in_data            = Input(UInt(16.W))")
         emit("val stream_in_startofpacket   = Input(Bool())")


### PR DESCRIPTION
Small change to argon that re-adds the generic streaming interface for Accel modules. This is just so that it can compile with the stream-vcs branch in spatial.